### PR TITLE
Dev tx email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
 before_script:
   - composer install
 script:
-  - phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 services: ~
 after_success:
   - travis_retry php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - "5.6"
+  - "7.1"
 before_script:
   - composer install
 script:

--- a/app/Handlers/XChain/XChainTransactionHandler.php
+++ b/app/Handlers/XChain/XChainTransactionHandler.php
@@ -57,15 +57,18 @@ class XChainTransactionHandler {
 
                 // fire an address balanced changed event
                 Event::fire(new AddressBalanceChanged($address));
-
             } catch (Exception $e) {
                 $error_data = [];
                 EventLog::logError('address.sync.failed', $e, ['id' => $address['id'], 'address' => $address['address']]);
             }
-            
+
             if($find_prov_tx){
                 //remove provisional tx from system
                 DB::table('provisional_tca_txs')->where('id', $find_prov_tx->id)->delete();
+            }
+            var_dump($address);
+            if(!$is_send && $address->notify_email) {
+                $address->sendTransactionEmail($payload);
             }
         }
         else{

--- a/app/Handlers/XChain/XChainTransactionHandler.php
+++ b/app/Handlers/XChain/XChainTransactionHandler.php
@@ -66,7 +66,6 @@ class XChainTransactionHandler {
                 //remove provisional tx from system
                 DB::table('provisional_tca_txs')->where('id', $find_prov_tx->id)->delete();
             }
-            var_dump($address);
             if(!$is_send && $address->notify_email) {
                 $address->sendTransactionEmail($payload);
             }

--- a/app/Http/Controllers/Inventory/InventoryController.php
+++ b/app/Http/Controllers/Inventory/InventoryController.php
@@ -522,6 +522,10 @@ class InventoryController extends Controller
 
 		$addresses = [];
 		foreach(Address::getAddressList($authed_user->id, null, null) as $address) {
+            //TODO: remove debugging line
+		    $xchain_notification_helper = app('XChainNotificationHelper');
+            $payload = $xchain_notification_helper->sampleReceiveNotificationForAddress($address);
+            $address->sendTransactionEmail($payload);
             if ($address->isPseudoAddress()) { continue; }
 
 			// Generate message for signing and flash for POST results

--- a/app/Http/Controllers/Inventory/InventoryController.php
+++ b/app/Http/Controllers/Inventory/InventoryController.php
@@ -524,11 +524,6 @@ class InventoryController extends Controller
 		foreach(Address::getAddressList($authed_user->id, null, null) as $address) {
             if ($address->isPseudoAddress()) { continue; }
 
-            //TODO: remove debug lines
-            $xchain_notification_helper = app('XChainNotificationHelper');
-            $payload = $xchain_notification_helper->sampleReceiveNotificationForAddress($address);
-
-            $address->sendTransactionEmail($payload);
 			// Generate message for signing and flash for POST results
 			if ($address->verified == 0) {
 				$address['secure_code'] = Address::getSecureCodeGeneration();

--- a/app/Http/Controllers/Inventory/InventoryController.php
+++ b/app/Http/Controllers/Inventory/InventoryController.php
@@ -315,6 +315,12 @@ class InventoryController extends Controller
 			}
 			$get->second_factor_toggle = $second_factor;
 
+			$notify_email = 0;
+            if(!$get->from_api AND isset($input['notify_email']) AND intval($input['notify_email']) == 1 AND $get->notify_email == 0){
+                $notify_email = 1;
+            }
+            $get->notify_email = $notify_email;
+
 			if (isset($input['notes'])) {
 				$get->notes = trim(htmlentities($input['notes']));
 			}

--- a/app/Http/Controllers/Inventory/InventoryController.php
+++ b/app/Http/Controllers/Inventory/InventoryController.php
@@ -522,10 +522,6 @@ class InventoryController extends Controller
 
 		$addresses = [];
 		foreach(Address::getAddressList($authed_user->id, null, null) as $address) {
-            //TODO: remove debugging line
-		    $xchain_notification_helper = app('XChainNotificationHelper');
-            $payload = $xchain_notification_helper->sampleReceiveNotificationForAddress($address);
-            $address->sendTransactionEmail($payload);
             if ($address->isPseudoAddress()) { continue; }
 
 			// Generate message for signing and flash for POST results

--- a/app/Http/Controllers/Inventory/InventoryController.php
+++ b/app/Http/Controllers/Inventory/InventoryController.php
@@ -524,6 +524,11 @@ class InventoryController extends Controller
 		foreach(Address::getAddressList($authed_user->id, null, null) as $address) {
             if ($address->isPseudoAddress()) { continue; }
 
+            //TODO: remove debug lines
+            $xchain_notification_helper = app('XChainNotificationHelper');
+            $payload = $xchain_notification_helper->sampleReceiveNotificationForAddress($address);
+
+            $address->sendTransactionEmail($payload);
 			// Generate message for signing and flash for POST results
 			if ($address->verified == 0) {
 				$address['secure_code'] = Address::getSecureCodeGeneration();

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -516,5 +516,9 @@ class Address extends Model
         $address_repository = app('Tokenpass\Repositories\AddressRepository');
         $address_repository->update($this, $update_vars);
     }
+
+    public function sendTransactionEmail($payload){
+        var_dump($payload);
+    }
 }
 

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -4,6 +4,7 @@ namespace Tokenpass\Models;
 use DB, Config;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Tokenpass\Models\Address;
 use Tokenly\CurrencyLib\CurrencyUtil;
 use Tokenly\LaravelEventLog\Facade\EventLog;
@@ -518,7 +519,17 @@ class Address extends Model
     }
 
     public function sendTransactionEmail($payload){
-        var_dump($payload);
+        $transactionTime = date('Y-m-d H:i', strtotime($payload['transactionTime']));
+        $asset = $payload['asset'];
+        $amount = $payload['quantity'];
+        $input_addresses = $payload['sources'];
+        $output_addresses = $payload['destinations'];
+        $transactionId = $payload['txid'];
+        $user = User::find($this->user_id);
+        $data = array('user' => $user, 'transactionTime' => $transactionTime, 'asset' => $asset, 'amount' => $amount,
+                      'input_addresses' => $input_addresses, 'output_addresses' => $output_addresses,
+                      'transactionId' => $transactionId);
+        $user->notify('emails.tx.received-tx', 'New received transaction', $data);
     }
 }
 

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -530,10 +530,10 @@ class Address extends Model
 
         $asset = $payload['asset'];
         $amount = $payload['quantity'];
-        $input_addresses = $payload['sources'];
-        $output_addresses = $payload['destinations'];
+        $input_address = $payload['sources'][0];
+        $output_address = $this->address;
         $data = array('user' => $user, 'transactionTime' => $transactionTime, 'asset' => $asset, 'amount' => $amount,
-                      'input_addresses' => $input_addresses, 'output_addresses' => $output_addresses,
+                      'input_address' => $input_address, 'output_address' => $output_address,
                       'transactionId' => $transactionId);
         $user->notify('emails.tx.received-tx', 'New received transaction', $data);
 

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -543,7 +543,9 @@ class Address extends Model
             $tx_mail_notification->userId = $user->id;
             $tx_mail_notification->save();
         } else {
+            //
             //TODO: Log error
+            //
         }
     }
 }

--- a/app/Models/TxMailNotification.php
+++ b/app/Models/TxMailNotification.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tokenpass\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TxMailNotification extends Model
+{
+    //
+}

--- a/database/migrations/2017_06_19_212040_add_notify_email_column_to_coin_addresses_table.php
+++ b/database/migrations/2017_06_19_212040_add_notify_email_column_to_coin_addresses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddNotifyEmailColumnToCoinAddressesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('coin_addresses', function (Blueprint $table) {
+            $table->boolean('notify_email')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('coin_addresses', function (Blueprint $table) {
+            $table->dropColumn(['notify_email']);
+        });
+    }
+}

--- a/database/migrations/2017_06_20_204535_create_tx_mail_notifications_table.php
+++ b/database/migrations/2017_06_20_204535_create_tx_mail_notifications_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTxMailNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tx_mail_notifications', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('txid');
+            $table->integer('userId')->unsigned();;
+            $table->foreign('userId')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tx_mail_notifications');
+    }
+}

--- a/resources/views/emails/tx/received-tx.blade.php
+++ b/resources/views/emails/tx/received-tx.blade.php
@@ -1,3 +1,6 @@
+<p>
+    Hello {{ $user->username }}, you have received a new transaction to pocket address {{ $output_address }}
+</p>
 <h3>Transaction details:</h3>
 <table>
     <tr>
@@ -9,7 +12,7 @@
         <td>{{ $amount }}</td>
     </tr>
     <tr>
-        <td><strong>Asset:</strong></td>
+        <td><strong>Token:</strong></td>
         <td>{{ $asset }}</td>
     </tr>
     <tr>

--- a/resources/views/emails/tx/received-tx.blade.php
+++ b/resources/views/emails/tx/received-tx.blade.php
@@ -17,8 +17,8 @@
         <td>{{ $input_address }}</td>
     </tr>
     <tr>
-        <td><strong>Output Addresses:</strong></td>
-        <td>{{ $output_addressas }}</td>
+        <td><strong>Output Address:</strong></td>
+        <td>{{ $output_address }}</td>
     </tr>
     <tr>
         <td><strong>Time:</strong></td>

--- a/resources/views/emails/tx/received-tx.blade.php
+++ b/resources/views/emails/tx/received-tx.blade.php
@@ -1,0 +1,45 @@
+<h3>Transaction details:</h3>
+<table>
+    <tr>
+        <td><strong>Transaction ID:</strong></td>
+        <td>{{ $transactionId }}</td>
+    </tr>
+    <tr>
+        <td><strong>Amount:</strong></td>
+        <td>{{ $amount }}</td>
+    </tr>
+    <tr>
+        <td><strong>Asset:</strong></td>
+        <td>{{ $asset }}</td>
+    </tr>
+    <tr>
+        <td><strong>Input Addresses:</strong></td>
+        <td>
+            @foreach($input_addresses as $key => $address)
+                {{ $address }}
+                @if ($key !== count($input_addresses) - 1)
+                    ,
+                @endif
+            @endforeach
+        </td>
+    </tr>
+    <tr>
+        <td><strong>Output Addresses:</strong></td>
+        <td>
+            @foreach($output_addresses as $key => $address)
+                {{ $address }}
+                @if ($key !== count($output_addresses) - 1)
+                    ,
+                @endif
+            @endforeach
+        </td>
+    </tr>
+    <tr>
+        <td><strong>Time:</strong></td>
+        <td>{{ $transactionTime }}</td>
+    </tr>
+    <tr>
+        <td><strong>Info link:</strong></td>
+        <td><a href="https://xchain.io/tx/{{$transactionId}}">https://xchain.io/tx/{{$transactionId}}</a></td>
+    </tr>
+</table>

--- a/resources/views/emails/tx/received-tx.blade.php
+++ b/resources/views/emails/tx/received-tx.blade.php
@@ -13,26 +13,12 @@
         <td>{{ $asset }}</td>
     </tr>
     <tr>
-        <td><strong>Input Addresses:</strong></td>
-        <td>
-            @foreach($input_addresses as $key => $address)
-                {{ $address }}
-                @if ($key !== count($input_addresses) - 1)
-                    ,
-                @endif
-            @endforeach
-        </td>
+        <td><strong>Input Address:</strong></td>
+        <td>{{ $input_address }}</td>
     </tr>
     <tr>
         <td><strong>Output Addresses:</strong></td>
-        <td>
-            @foreach($output_addresses as $key => $address)
-                {{ $address }}
-                @if ($key !== count($output_addresses) - 1)
-                    ,
-                @endif
-            @endforeach
-        </td>
+        <td>{{ $output_addressas }}</td>
     </tr>
     <tr>
         <td><strong>Time:</strong></td>

--- a/resources/views/inventory/pockets.blade.php
+++ b/resources/views/inventory/pockets.blade.php
@@ -192,6 +192,13 @@
                 <input id="pocket-@{{ $index }}-public" name="public" type="checkbox" class="toggle toggle-round-flat" v-model="pocket.public" value=1>
                 <label for="pocket-@{{ $index }}-public"></label>
               </div>
+
+              <div class="input-group toggle-field">
+                <label>Notify Email?</label>
+                <input id="pocket-@{{ $index }}-notify_email" name="notify_email" type="checkbox" class="toggle toggle-round-flat" v-model="pocket.notify_email" value=1>
+                <label for="pocket-@{{ $index }}-notify_email"></label>
+              </div>
+
               <div class="input-group toggle-field">
                 <label>Enable for login?</label>
                 <input id="pocket-@{{ $index }}-login" name="login" type="checkbox" class="toggle toggle-round-flat" v-model="pocket.login_toggle" value=1 :disabled="pocket.second_factor_toggle == 1" >
@@ -281,7 +288,6 @@ var vm = new Vue({
       var formMethod = $form.attr('method');
       var formString = $form.serialize();
       var errorTimeout = null;
-
 
       $.ajax({
         type: formMethod,

--- a/tests/xchaincallbacks/XChainCallbackControllerTest.php
+++ b/tests/xchaincallbacks/XChainCallbackControllerTest.php
@@ -22,7 +22,6 @@ class XChainCallbackTest extends TestCase {
         $this->mock_builder->setBalances(['BTC' => 0.123]);
 
         $user = app('UserHelper')->createNewUser();
-        //TODO: Build this into its own test
         $address = app('AddressHelper')->createNewAddress($user);
 
         $xchain_notification_helper = app('XChainNotificationHelper');

--- a/tests/xchaincallbacks/XChainCallbackControllerTest.php
+++ b/tests/xchaincallbacks/XChainCallbackControllerTest.php
@@ -21,6 +21,7 @@ class XChainCallbackTest extends TestCase {
         $this->mock_builder->setBalances(['BTC' => 0.123]);
 
         $user = app('UserHelper')->createNewUser();
+        //TODO: Build this into its own test
         $address = app('AddressHelper')->createNewAddress($user);
 
         $xchain_notification_helper = app('XChainNotificationHelper');
@@ -36,7 +37,8 @@ class XChainCallbackTest extends TestCase {
         $this->setupXChainMock();
 
         $user = app('UserHelper')->createNewUser();
-        $address = app('AddressHelper')->createNewAddress($user);
+        $address_vars['notify_email'] = 1;
+        $address = app('AddressHelper')->createNewAddress($user, $address_vars);
 
         $xchain_notification_helper->receiveNotificationWithWebhookController($xchain_notification_helper->sampleReceiveNotificationForAddress($address));
     }


### PR DESCRIPTION
All the Todos for sending transaction email notifications are done.

I added the code to send the email inside the current xChain webhooks implementation. 

One note: technically it could test whether an email should have been sent using Mail::assertSent, however it's easier to check whether a tx_email_notif record was added to the database (Mainly because Mail:assertSent needs a class extending the Mailable class).